### PR TITLE
Changed encoding to UTF-8

### DIFF
--- a/Source/Rhetos.AfterDeploy/ExecuteSqlAfterDeploy.cs
+++ b/Source/Rhetos.AfterDeploy/ExecuteSqlAfterDeploy.cs
@@ -69,7 +69,7 @@ namespace Rhetos.AfterDeploy
             foreach (var script in scripts)
             {
                 _logger.Trace("Executing script " + script.Package.Id + ": " + script.Name);
-                string sql = File.ReadAllText(script.Path, Encoding.Default);
+                string sql = File.ReadAllText(script.Path, Encoding.UTF8);
 
                 var sqlBatches = SqlTransactionBatch.GroupByTransaction(SqlUtility.SplitBatches(sql));
                 foreach (var sqlBatch in sqlBatches)


### PR DESCRIPTION
you should use a Unicode encoding, such as UTF8Encoding.

Motivation: plugin converts chars 'č','ž','š'... into gibberish.
source: https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.default?view=netframework-4.8